### PR TITLE
chore: bump SearXNG from 2025.10.15 to 2026.3.13 (security)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache yq;\
     mv /usr/bin/yq /usr/local/bin/;\
     rm -f /var/cache/apk/*
 
-FROM searxng/searxng:2025.10.15-576d30ffc AS final
+FROM searxng/searxng:2026.3.13-3c1f68c59 AS final
 
 USER root
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,17 +1,18 @@
 id: searxng
 title: "SearXNG"
-version: 2025.10.15
+version: 2026.3.13
 release-notes: |
-  - Updated SearXNG code to the latest upstream version.
+  - Updated SearXNG from 2025.10.15 to 2026.3.13.
+
+  > **SECURITY**
+    - **XSS Fix:** Patched unsafe rendering of untrusted external data.
 
   > **Highlights**
-    - **New Azure Search:** You can now search Azure cloud resources directly in SearXNG.
-    - **Video Search Improvement:** See video lengths in search results at a glance.
-    - **Pinterest and Weather Fixes:** Pinterest results and the !weather command are now more reliable.
-    - **Safer Search:** SafeSearch on Startpage now filters results correctly.
-    - **Smarter Google Scholar:** Better handling when Google asks for CAPTCHA.
-
-    - Interface and stability updates throughout for a smoother experience.
+    - **DuckDuckGo Overhaul:** Complete rewrite of all DuckDuckGo engines.
+    - **Google Engine Fixes:** Fixed broken Google engine XPaths.
+    - **New Engines:** Bing autocompleter, Pexels, ArtStation, NIST.gov.
+    - **Removed Engines:** Right Dao, Stract, Livespace, Searchcode, Seekr.
+    - **Performance:** Dropped fasttext-predict dependency, adjusted suspended_times defaults, removed Sec-Fetch-* headers.
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/searxng-startos"
 upstream-repo: "https://github.com/searxng/searxng-docker"


### PR DESCRIPTION
## Summary

- Bumps SearXNG Docker image from `2025.10.15-576d30ffc` to `2026.3.13-3c1f68c59`
- Updates `manifest.yaml` version and release notes

## Security

**XSS Fix:** Patched unsafe rendering of untrusted external data. This is the primary motivation for this update.

## Upstream Changes (2025.10.15 → 2026.3.13)

### Engine Changes
- **DuckDuckGo:** Complete overhaul of all DuckDuckGo engines
- **Google:** Fixed broken Google engine XPaths
- **New engines:** Bing autocompleter, Pexels, ArtStation, NIST.gov
- **Removed engines:** Right Dao, Stract, Livespace, Searchcode, Seekr

### Other
- Removed Sec-Fetch-* headers
- Adjusted suspended_times defaults
- Dropped fasttext-predict dependency

## Files Changed
- `Dockerfile` — Updated `FROM` image tag
- `manifest.yaml` — Updated version and release notes