### PR TITLE
chore: bump SearXNG to 2026.5.29; 2026.5.17:2 → 2026.5.29:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -342,7 +342,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.5.17-d7e8b7cd1',
+        dockerTag: 'searxng/searxng:2026.5.29-217c9a159',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -2,7 +2,7 @@ import { IMPOSSIBLE, VersionInfo, YAML } from '@start9labs/start-sdk'
 import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
-export const v_2026_5_29_0 = VersionInfo.of({
+export const current = VersionInfo.of({
   version: '2026.5.29:0',
   releaseNotes: {
     en_US: 'Bumps SearXNG → 2026.5.29.',

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_2026_5_17_2 } from './v2026.5.17.2'
+import { v_2026_5_29_0 } from './v2026.5.29.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2026_5_17_2,
+  current: v_2026_5_29_0,
   other: [],
 })

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_2026_5_29_0 } from './v2026.5.29.0'
+import { current } from './current'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2026_5_29_0,
+  current,
   other: [],
 })

--- a/startos/versions/v2026.5.29.0.ts
+++ b/startos/versions/v2026.5.29.0.ts
@@ -2,14 +2,14 @@ import { IMPOSSIBLE, VersionInfo, YAML } from '@start9labs/start-sdk'
 import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
-export const v_2026_5_17_2 = VersionInfo.of({
-  version: '2026.5.17:2',
+export const v_2026_5_29_0 = VersionInfo.of({
+  version: '2026.5.29:0',
   releaseNotes: {
-    en_US: 'Upstream patch: adds cara.app search engine.',
-    es_ES: 'Parche de upstream: añade el motor de búsqueda cara.app.',
-    de_DE: 'Upstream-Patch: fügt die Suchmaschine cara.app hinzu.',
-    pl_PL: 'Łatka upstream: dodaje wyszukiwarkę cara.app.',
-    fr_FR: 'Correctif amont : ajoute le moteur de recherche cara.app.',
+    en_US: 'Bumps SearXNG → 2026.5.29.',
+    es_ES: 'Actualiza SearXNG → 2026.5.29.',
+    de_DE: 'Aktualisiert SearXNG → 2026.5.29.',
+    pl_PL: 'Aktualizuje SearXNG → 2026.5.29.',
+    fr_FR: 'Met à jour SearXNG → 2026.5.29.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps SearXNG to the latest upstream continuous release: `searxng/searxng:2026.5.17-d7e8b7cd1` → `searxng/searxng:2026.5.29-217c9a159`.
- StartOS version `2026.5.17:2` → `2026.5.29:0` (new upstream resets the downstream revision to `0`).
- `npm update` refreshed transitive deps only; `@start9labs/start-sdk` is already at the latest published version (1.5.3), so no SDK bump.

## Details

- SearXNG ships continuously (dated Docker tags, no GitHub releases), so this is a routine rolling upstream bump with no API/behavior changes on our side.
- No new actions, volumes, ports, interfaces, or dependencies — `README.md` and `instructions.md` need no changes.
- The existing config-migration (`start9/config.yaml` → `settings.yml`) carries forward unchanged on `current`, per this repo's version-file convention (rename-in-place to the new version string; `other` stays `[]`).
- Sidecar pins (`valkey/valkey:8-alpine`, `caddy:2-alpine`) are rolling major tags and were left as-is — both are still on their current majors.

## Proposal (not implemented)

- Valkey 9.x is now released upstream (latest `9.1.0`), while we pin the rolling `8-alpine` tag. Moving to `valkey/valkey:9-alpine` is a deliberate major bump (out of scope for a monitor cycle); happy to do it in a follow-up if we want to track Valkey 9.

## Test plan

- [x] `npm run check` (tsc --noEmit) passes.
- [ ] `make` builds the `.s9pk` (verified in review).
- [ ] Install/upgrade to `2026.5.29:0` and confirm SearXNG starts and serves search.