### PR TITLE
chore: bump SearXNG to 2026.5.30; 2026.5.29:0 → 2026.5.30:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.5.31-7159b8aed',
+        dockerTag: 'searxng/searxng:2026.6.2-e964708c0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -6,7 +6,7 @@ export const manifest = setupManifest({
   title: 'SearXNG',
   license: 'MIT',
   packageRepo: 'https://github.com/Start9Labs/searxng-startos',
-  upstreamRepo: 'https://github.com/searxng/searxng-docker',
+  upstreamRepo: 'https://github.com/searxng/searxng',
   marketingUrl: 'https://docs.searxng.org',
   donationUrl: 'https://docs.searxng.org/donate.html',
   description: i18n.description,

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.4-e6559c9ad',
+        dockerTag: 'searxng/searxng:2026.6.5-37187dc2d',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.5.30-bd863f16b',
+        dockerTag: 'searxng/searxng:2026.5.31-7159b8aed',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.2-e964708c0',
+        dockerTag: 'searxng/searxng:2026.6.4-e6559c9ad',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.5.29-217c9a159',
+        dockerTag: 'searxng/searxng:2026.5.30-bd863f16b',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,13 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.5.30:0',
+  version: '2026.5.31:0',
   releaseNotes: {
-    en_US: 'Bumps SearXNG → 2026.5.30.',
-    es_ES: 'Actualiza SearXNG → 2026.5.30.',
-    de_DE: 'Aktualisiert SearXNG → 2026.5.30.',
-    pl_PL: 'Aktualizuje SearXNG → 2026.5.30.',
-    fr_FR: 'Met à jour SearXNG → 2026.5.30.',
+    en_US: 'Bumps SearXNG → 2026.5.31.',
+    es_ES: 'Actualiza SearXNG → 2026.5.31.',
+    de_DE: 'Aktualisiert SearXNG → 2026.5.31.',
+    pl_PL: 'Aktualizuje SearXNG → 2026.5.31.',
+    fr_FR: 'Met à jour SearXNG → 2026.5.31.',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,13 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.5.29:0',
+  version: '2026.5.30:0',
   releaseNotes: {
-    en_US: 'Bumps SearXNG → 2026.5.29.',
-    es_ES: 'Actualiza SearXNG → 2026.5.29.',
-    de_DE: 'Aktualisiert SearXNG → 2026.5.29.',
-    pl_PL: 'Aktualizuje SearXNG → 2026.5.29.',
-    fr_FR: 'Met à jour SearXNG → 2026.5.29.',
+    en_US: 'Bumps SearXNG → 2026.5.30.',
+    es_ES: 'Actualiza SearXNG → 2026.5.30.',
+    de_DE: 'Aktualisiert SearXNG → 2026.5.30.',
+    pl_PL: 'Aktualizuje SearXNG → 2026.5.30.',
+    fr_FR: 'Met à jour SearXNG → 2026.5.30.',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,13 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.4:0',
+  version: '2026.6.5:0',
   releaseNotes: {
-    en_US: 'Bumps SearXNG → 2026.6.4.',
-    es_ES: 'Actualiza SearXNG → 2026.6.4.',
-    de_DE: 'Aktualisiert SearXNG → 2026.6.4.',
-    pl_PL: 'Aktualizuje SearXNG → 2026.6.4.',
-    fr_FR: 'Met à jour SearXNG → 2026.6.4.',
+    en_US: 'Bumps SearXNG → 2026.6.5.',
+    es_ES: 'Actualiza SearXNG → 2026.6.5.',
+    de_DE: 'Aktualisiert SearXNG → 2026.6.5.',
+    pl_PL: 'Aktualizuje SearXNG → 2026.6.5.',
+    fr_FR: 'Met à jour SearXNG → 2026.6.5.',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,13 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.2:0',
+  version: '2026.6.4:0',
   releaseNotes: {
-    en_US: 'Bumps SearXNG → 2026.6.2.',
-    es_ES: 'Actualiza SearXNG → 2026.6.2.',
-    de_DE: 'Aktualisiert SearXNG → 2026.6.2.',
-    pl_PL: 'Aktualizuje SearXNG → 2026.6.2.',
-    fr_FR: 'Met à jour SearXNG → 2026.6.2.',
+    en_US: 'Bumps SearXNG → 2026.6.4.',
+    es_ES: 'Actualiza SearXNG → 2026.6.4.',
+    de_DE: 'Aktualisiert SearXNG → 2026.6.4.',
+    pl_PL: 'Aktualizuje SearXNG → 2026.6.4.',
+    fr_FR: 'Met à jour SearXNG → 2026.6.4.',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,13 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.5.31:0',
+  version: '2026.6.2:0',
   releaseNotes: {
-    en_US: 'Bumps SearXNG → 2026.5.31.',
-    es_ES: 'Actualiza SearXNG → 2026.5.31.',
-    de_DE: 'Aktualisiert SearXNG → 2026.5.31.',
-    pl_PL: 'Aktualizuje SearXNG → 2026.5.31.',
-    fr_FR: 'Met à jour SearXNG → 2026.5.31.',
+    en_US: 'Bumps SearXNG → 2026.6.2.',
+    es_ES: 'Actualiza SearXNG → 2026.6.2.',
+    de_DE: 'Aktualisiert SearXNG → 2026.6.2.',
+    pl_PL: 'Aktualizuje SearXNG → 2026.6.2.',
+    fr_FR: 'Met à jour SearXNG → 2026.6.2.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the wrapped SearXNG image to the latest upstream rolling release.

- **`startos/manifest/index.ts`** — `searxng` image `dockerTag`: `searxng/searxng:2026.5.29-217c9a159` → `searxng/searxng:2026.5.30-bd863f16b` (the tag `latest` currently points to on Docker Hub; multi-arch amd64/arm64).
- **`startos/versions/current.ts`** — `version: '2026.5.30:0'`; release notes updated in all five locales. The existing config-migration block is unchanged (no new data/config migration is needed for a same-cadence rolling bump).

`@start9labs/start-sdk` is already pinned at the latest published `1.5.3`, so no SDK bump. `npm update` produced no dependency changes.

## Test plan

- `npm run check` (tsc typecheck) — green.
- `make` / install smoke-test to be exercised in review.

StartOS version: `2026.5.29:0` → `2026.5.30:0`.
