### PR TITLE
chore: bump SearXNG to 2026.6.7; 2026.6.5:0 → 2026.6.7:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,18 @@
         "ncc": "dist/ncc/cli.js"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/deep-equality-data-structures/-/deep-equality-data-structures-2.0.0.tgz",
@@ -231,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -247,16 +259,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.10-f4c63c8eb',
+        dockerTag: 'searxng/searxng:2026.6.12-de8a3de15',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.5-37187dc2d',
+        dockerTag: 'searxng/searxng:2026.6.7-86903a2c6',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.8-f3fab143b',
+        dockerTag: 'searxng/searxng:2026.6.10-f4c63c8eb',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.7-86903a2c6',
+        dockerTag: 'searxng/searxng:2026.6.8-f3fab143b',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,13 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.5:0',
+  version: '2026.6.7:0',
   releaseNotes: {
-    en_US: 'Bumps SearXNG → 2026.6.5.',
-    es_ES: 'Actualiza SearXNG → 2026.6.5.',
-    de_DE: 'Aktualisiert SearXNG → 2026.6.5.',
-    pl_PL: 'Aktualizuje SearXNG → 2026.6.5.',
-    fr_FR: 'Met à jour SearXNG → 2026.6.5.',
+    en_US: 'Bumps SearXNG → 2026.6.7.',
+    es_ES: 'Actualiza SearXNG → 2026.6.7.',
+    de_DE: 'Aktualisiert SearXNG → 2026.6.7.',
+    pl_PL: 'Aktualizuje SearXNG → 2026.6.7.',
+    fr_FR: 'Met à jour SearXNG → 2026.6.7.',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,38 +3,38 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.8:0',
+  version: '2026.6.10:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.8.
+    en_US: `Updated SearXNG to 2026.6.10.
 
-- New search engines: heexy (general, images), seek-ninja (general), tiger.ch.
-- Fixes: aol now uses the Wikidata ID for C++; yep sends Sec-Fetch headers to bypass "access denied".
+- New DuckDuckGo web engine as an alternative to html.duckduckgo.com.
+- Hardening: the SQLite database schema is now created during app initialization.
 
-Full changes: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
-    es_ES: `Actualiza SearXNG a 2026.6.8.
+Full changes: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
+    es_ES: `Actualiza SearXNG a 2026.6.10.
 
-- Nuevos motores de búsqueda: heexy (general, imágenes), seek-ninja (general), tiger.ch.
-- Correcciones: aol ahora usa el ID de Wikidata para C++; yep envía cabeceras Sec-Fetch para evitar el «acceso denegado».
+- Nuevo motor web de DuckDuckGo como alternativa a html.duckduckgo.com.
+- Refuerzo: el esquema de la base de datos SQLite ahora se crea durante la inicialización de la aplicación.
 
-Cambios completos: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.8.
+Cambios completos: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.10.
 
-- Neue Suchmaschinen: heexy (allgemein, Bilder), seek-ninja (allgemein), tiger.ch.
-- Korrekturen: aol verwendet nun die Wikidata-ID für C++; yep sendet Sec-Fetch-Header, um „Zugriff verweigert“ zu umgehen.
+- Neue DuckDuckGo-Web-Suchmaschine als Alternative zu html.duckduckgo.com.
+- Härtung: Das SQLite-Datenbankschema wird nun während der App-Initialisierung erstellt.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.8.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.10.
 
-- Nowe wyszukiwarki: heexy (ogólna, obrazy), seek-ninja (ogólna), tiger.ch.
-- Poprawki: aol używa teraz identyfikatora Wikidata dla C++; yep wysyła nagłówki Sec-Fetch, aby ominąć „odmowę dostępu”.
+- Nowa wyszukiwarka internetowa DuckDuckGo jako alternatywa dla html.duckduckgo.com.
+- Wzmocnienie: schemat bazy danych SQLite jest teraz tworzony podczas inicjalizacji aplikacji.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.8.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.10.
 
-- Nouveaux moteurs de recherche : heexy (général, images), seek-ninja (général), tiger.ch.
-- Corrections : aol utilise désormais l'identifiant Wikidata pour le C++ ; yep envoie les en-têtes Sec-Fetch pour contourner « accès refusé ».
+- Nouveau moteur web DuckDuckGo en alternative à html.duckduckgo.com.
+- Renforcement : le schéma de la base de données SQLite est désormais créé lors de l'initialisation de l'application.
 
-Changements complets : https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
+Changements complets : https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,38 +3,38 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.10:0',
+  version: '2026.6.12:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.10.
+    en_US: `Updated SearXNG to 2026.6.12.
 
-- New DuckDuckGo web engine as an alternative to html.duckduckgo.com.
-- Hardening: the SQLite database schema is now created during app initialization.
+- New search engines: Fireball (general, news, videos) and Dogpile (general, news, images, videos).
+- Added support for Kagi (requires an API key).
 
-Full changes: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
-    es_ES: `Actualiza SearXNG a 2026.6.10.
+Full changes: https://github.com/searxng/searxng/compare/f4c63c8eb...de8a3de15`,
+    es_ES: `Actualiza SearXNG a 2026.6.12.
 
-- Nuevo motor web de DuckDuckGo como alternativa a html.duckduckgo.com.
-- Refuerzo: el esquema de la base de datos SQLite ahora se crea durante la inicialización de la aplicación.
+- Nuevos motores de búsqueda: Fireball (general, noticias, vídeos) y Dogpile (general, noticias, imágenes, vídeos).
+- Se añade compatibilidad con Kagi (requiere una clave de API).
 
-Cambios completos: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.10.
+Cambios completos: https://github.com/searxng/searxng/compare/f4c63c8eb...de8a3de15`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.12.
 
-- Neue DuckDuckGo-Web-Suchmaschine als Alternative zu html.duckduckgo.com.
-- Härtung: Das SQLite-Datenbankschema wird nun während der App-Initialisierung erstellt.
+- Neue Suchmaschinen: Fireball (allgemein, Nachrichten, Videos) und Dogpile (allgemein, Nachrichten, Bilder, Videos).
+- Unterstützung für Kagi hinzugefügt (erfordert einen API-Schlüssel).
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.10.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/f4c63c8eb...de8a3de15`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.12.
 
-- Nowa wyszukiwarka internetowa DuckDuckGo jako alternatywa dla html.duckduckgo.com.
-- Wzmocnienie: schemat bazy danych SQLite jest teraz tworzony podczas inicjalizacji aplikacji.
+- Nowe wyszukiwarki: Fireball (ogólne, wiadomości, wideo) oraz Dogpile (ogólne, wiadomości, obrazy, wideo).
+- Dodano obsługę Kagi (wymaga klucza API).
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.10.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/f4c63c8eb...de8a3de15`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.12.
 
-- Nouveau moteur web DuckDuckGo en alternative à html.duckduckgo.com.
-- Renforcement : le schéma de la base de données SQLite est désormais créé lors de l'initialisation de l'application.
+- Nouveaux moteurs de recherche : Fireball (général, actualités, vidéos) et Dogpile (général, actualités, images, vidéos).
+- Ajout de la prise en charge de Kagi (nécessite une clé API).
 
-Changements complets : https://github.com/searxng/searxng/compare/f3fab143b...f4c63c8eb`,
+Changements complets : https://github.com/searxng/searxng/compare/f4c63c8eb...de8a3de15`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,38 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.7:0',
+  version: '2026.6.8:0',
   releaseNotes: {
-    en_US: 'Bumps SearXNG → 2026.6.7.',
-    es_ES: 'Actualiza SearXNG → 2026.6.7.',
-    de_DE: 'Aktualisiert SearXNG → 2026.6.7.',
-    pl_PL: 'Aktualizuje SearXNG → 2026.6.7.',
-    fr_FR: 'Met à jour SearXNG → 2026.6.7.',
+    en_US: `Updated SearXNG to 2026.6.8.
+
+- New search engines: heexy (general, images), seek-ninja (general), tiger.ch.
+- Fixes: aol now uses the Wikidata ID for C++; yep sends Sec-Fetch headers to bypass "access denied".
+
+Full changes: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
+    es_ES: `Actualiza SearXNG a 2026.6.8.
+
+- Nuevos motores de búsqueda: heexy (general, imágenes), seek-ninja (general), tiger.ch.
+- Correcciones: aol ahora usa el ID de Wikidata para C++; yep envía cabeceras Sec-Fetch para evitar el «acceso denegado».
+
+Cambios completos: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.8.
+
+- Neue Suchmaschinen: heexy (allgemein, Bilder), seek-ninja (allgemein), tiger.ch.
+- Korrekturen: aol verwendet nun die Wikidata-ID für C++; yep sendet Sec-Fetch-Header, um „Zugriff verweigert“ zu umgehen.
+
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.8.
+
+- Nowe wyszukiwarki: heexy (ogólna, obrazy), seek-ninja (ogólna), tiger.ch.
+- Poprawki: aol używa teraz identyfikatora Wikidata dla C++; yep wysyła nagłówki Sec-Fetch, aby ominąć „odmowę dostępu”.
+
+Pełna lista zmian: https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.8.
+
+- Nouveaux moteurs de recherche : heexy (général, images), seek-ninja (général), tiger.ch.
+- Corrections : aol utilise désormais l'identifiant Wikidata pour le C++ ; yep envoie les en-têtes Sec-Fetch pour contourner « accès refusé ».
+
+Changements complets : https://github.com/searxng/searxng/compare/2026.6.7-86903a2c6...2026.6.8-f3fab143b`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Monitor-cycle upstream bump for SearXNG.

- **SearXNG** `2026.6.5` → `2026.6.7` — `images.searxng.source.dockerTag` set to `searxng/searxng:2026.6.7-86903a2c6` (newest non-`latest` tag on Docker Hub).
- StartOS version: `2026.6.5:0` → `2026.6.7:0` (in-place edit of `startos/versions/current.ts`, no migration change).
- Sidecars unchanged: `valkey/valkey:8-alpine` and `caddy:2-alpine` remain on their rolling major tags (no major bump upstream).
- `@start9labs/start-sdk` already at latest `1.5.3` — no SDK bump. `npm update` refreshed `@types/node` `20.19.41` → `20.19.42`.

## Test plan

- `npm run check` (tsc typecheck) — green.

Full `make` / s9pk verification happens in PR review.