### PR TITLE
chore: bump SearXNG to 2026.6.15; 2026.6.14:0 → 2026.6.15:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
@@ -270,7 +270,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.0.tgz",
-      "integrity": "sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.0.tgz",
+      "integrity": "sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==",
       "funding": [
         {
           "type": "github",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.15-cf1410af8',
+        dockerTag: 'searxng/searxng:2026.6.16-502c820a2',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.22-952896d29',
+        dockerTag: 'searxng/searxng:2026.6.24-e3126b89e',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.16-502c820a2',
+        dockerTag: 'searxng/searxng:2026.6.18-bd73cc09e',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.20-fd42d4fda',
+        dockerTag: 'searxng/searxng:2026.6.22-952896d29',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.18-bd73cc09e',
+        dockerTag: 'searxng/searxng:2026.6.19-5c38d2fea',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.19-5c38d2fea',
+        dockerTag: 'searxng/searxng:2026.6.20-fd42d4fda',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.14-b3e08f2a4',
+        dockerTag: 'searxng/searxng:2026.6.15-cf1410af8',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,38 +3,23 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.14:0',
+  version: '2026.6.15:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.14.
+    en_US: `Updated SearXNG to 2026.6.15. A small maintenance release: normalized engine configuration attributes and fixed language support for engines that declare their languages via traits.
 
-- New search engines: vuhuv, Podchaser (podcasts), PrivacyWall, fastbot, reloado, rawweb, Luxxle, t-online, ayo.de and searchzee.
-- New "Manage Access" action: optionally require a login (username "admin" plus a password you set) to use your instance — covers both the Web UI and the Stats Dashboard. Instances remain public by default.
+Full changes: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
+    es_ES: `Actualiza SearXNG a 2026.6.15. Una pequeña versión de mantenimiento: se normalizaron los atributos de configuración de los motores y se corrigió el soporte de idiomas para los motores que declaran sus idiomas mediante traits.
 
-Full changes: https://github.com/searxng/searxng/compare/d14fa1f6e...b3e08f2a4`,
-    es_ES: `Actualiza SearXNG a 2026.6.14.
+Cambios completos: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.15. Eine kleine Wartungsversion: Die Konfigurationsattribute der Suchmaschinen wurden normalisiert und die Sprachunterstützung für Suchmaschinen behoben, die ihre Sprachen über Traits angeben.
 
-- Nuevos motores de búsqueda: vuhuv, Podchaser (podcasts), PrivacyWall, fastbot, reloado, rawweb, Luxxle, t-online, ayo.de y searchzee.
-- Nueva acción "Gestionar acceso": opcionalmente requiere un inicio de sesión (usuario "admin" y una contraseña que usted establece) para usar su instancia, protegiendo tanto la interfaz web como el panel de estadísticas. Las instancias siguen siendo públicas de forma predeterminada.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.15. Niewielkie wydanie konserwacyjne: znormalizowano atrybuty konfiguracji wyszukiwarek i naprawiono obsługę języków dla wyszukiwarek deklarujących swoje języki za pomocą traits.
 
-Cambios completos: https://github.com/searxng/searxng/compare/d14fa1f6e...b3e08f2a4`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.14.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.15. Une petite version de maintenance : normalisation des attributs de configuration des moteurs et correction de la prise en charge des langues pour les moteurs qui déclarent leurs langues via des traits.
 
-- Neue Suchmaschinen: vuhuv, Podchaser (Podcasts), PrivacyWall, fastbot, reloado, rawweb, Luxxle, t-online, ayo.de und searchzee.
-- Neue Aktion „Zugriff verwalten": optional eine Anmeldung erforderlich machen (Benutzer „admin" plus ein von Ihnen festgelegtes Passwort), um Ihre Instanz zu nutzen — schützt sowohl die Web-UI als auch das Statistik-Dashboard. Instanzen bleiben standardmäßig öffentlich.
-
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/d14fa1f6e...b3e08f2a4`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.14.
-
-- Nowe wyszukiwarki: vuhuv, Podchaser (podcasty), PrivacyWall, fastbot, reloado, rawweb, Luxxle, t-online, ayo.de oraz searchzee.
-- Nowa akcja „Zarządzaj dostępem": opcjonalnie wymagaj logowania (użytkownik „admin" oraz hasło, które ustalasz), aby korzystać z instancji — chroni zarówno interfejs webowy, jak i panel statystyk. Instancje domyślnie pozostają publiczne.
-
-Pełna lista zmian: https://github.com/searxng/searxng/compare/d14fa1f6e...b3e08f2a4`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.14.
-
-- Nouveaux moteurs de recherche : vuhuv, Podchaser (podcasts), PrivacyWall, fastbot, reloado, rawweb, Luxxle, t-online, ayo.de et searchzee.
-- Nouvelle action « Gérer l'accès » : exiger en option une connexion (utilisateur « admin » plus un mot de passe que vous définissez) pour utiliser votre instance — protège à la fois l'interface web et le tableau de bord des statistiques. Les instances restent publiques par défaut.
-
-Changements complets : https://github.com/searxng/searxng/compare/d14fa1f6e...b3e08f2a4`,
+Changements complets : https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,23 +3,23 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.18:0',
+  version: '2026.6.19:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.18. Adds the Swiss search.ch/web engine and fixes the chinaso engine to handle empty upstream results gracefully.
+    en_US: `Updated SearXNG to 2026.6.19. A maintenance release: fixes a calculator crash on invalid expressions, assigns proper categories to several xpath engines (ayo, gabanza, zapmeta, abcnyheter), and refreshes translations.
 
-Full changes: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
-    es_ES: `Actualiza SearXNG a 2026.6.18. Añade el motor suizo search.ch/web y corrige el motor chinaso para gestionar correctamente los resultados vacíos del proveedor.
+Full changes: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
+    es_ES: `Actualiza SearXNG a 2026.6.19. Versión de mantenimiento: corrige un fallo de la calculadora con expresiones no válidas, asigna categorías correctas a varios motores xpath (ayo, gabanza, zapmeta, abcnyheter) y actualiza las traducciones.
 
-Cambios completos: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.18. Fügt die Schweizer Suchmaschine search.ch/web hinzu und behebt die chinaso-Suchmaschine, sodass leere Ergebnisse der Quelle korrekt behandelt werden.
+Cambios completos: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.19. Eine Wartungsversion: behebt einen Absturz des Taschenrechners bei ungültigen Ausdrücken, weist mehreren xpath-Suchmaschinen (ayo, gabanza, zapmeta, abcnyheter) korrekte Kategorien zu und aktualisiert die Übersetzungen.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.18. Dodaje szwajcarską wyszukiwarkę search.ch/web i naprawia wyszukiwarkę chinaso, aby poprawnie obsługiwała puste wyniki z serwera źródłowego.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.19. Wydanie konserwacyjne: naprawia awarię kalkulatora przy nieprawidłowych wyrażeniach, przypisuje właściwe kategorie kilku wyszukiwarkom xpath (ayo, gabanza, zapmeta, abcnyheter) i odświeża tłumaczenia.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.18. Ajoute le moteur suisse search.ch/web et corrige le moteur chinaso pour gérer correctement les résultats vides du fournisseur.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.19. Une version de maintenance : corrige un plantage de la calculatrice sur les expressions invalides, attribue des catégories correctes à plusieurs moteurs xpath (ayo, gabanza, zapmeta, abcnyheter) et met à jour les traductions.
 
-Changements complets : https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
+Changements complets : https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,43 +3,38 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.22:0',
+  version: '2026.6.24:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.22.
+    en_US: `Updated SearXNG to 2026.6.24. A small maintenance release.
 
-- Adds several new search engines (tusksearch, giphy, iseek, findfiles, and others) and a new "blogs" category.
-- Image results now guess their mimetype from the file path.
-- Removes the discontinued AOL engine and bumps Python dependencies.
+- Fixes the Anaconda engine's missing "about" configuration.
+- Removes the terminated ChinaSo media engines.
 
-Full changes: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
-    es_ES: `Actualiza SearXNG a 2026.6.22.
+Full changes: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+    es_ES: `Actualiza SearXNG a 2026.6.24. Una pequeña versión de mantenimiento.
 
-- Añade varios motores de búsqueda nuevos (tusksearch, giphy, iseek, findfiles y otros) y una nueva categoría "blogs".
-- Los resultados de imágenes ahora deducen su tipo MIME a partir de la ruta del archivo.
-- Elimina el motor AOL descontinuado y actualiza las dependencias de Python.
+- Corrige la configuración "about" que faltaba en el motor Anaconda.
+- Elimina los motores de medios ChinaSo descontinuados.
 
-Cambios completos: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.22.
+Cambios completos: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.24. Eine kleine Wartungsversion.
 
-- Fügt mehrere neue Suchmaschinen (tusksearch, giphy, iseek, findfiles und weitere) sowie eine neue Kategorie "Blogs" hinzu.
-- Bildergebnisse ermitteln ihren MIME-Typ jetzt anhand des Dateipfads.
-- Entfernt die eingestellte AOL-Suchmaschine und aktualisiert die Python-Abhängigkeiten.
+- Behebt die fehlende "about"-Konfiguration der Anaconda-Suchmaschine.
+- Entfernt die eingestellten ChinaSo-Medien-Suchmaschinen.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.22.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.24. Niewielka wersja konserwacyjna.
 
-- Dodaje kilka nowych wyszukiwarek (tusksearch, giphy, iseek, findfiles i inne) oraz nową kategorię „blogi".
-- Wyniki obrazów określają teraz typ MIME na podstawie ścieżki pliku.
-- Usuwa wycofaną wyszukiwarkę AOL i aktualizuje zależności Pythona.
+- Naprawia brakującą konfigurację „about" w wyszukiwarce Anaconda.
+- Usuwa wycofane wyszukiwarki multimediów ChinaSo.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.22.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.24. Une petite version de maintenance.
 
-- Ajoute plusieurs nouveaux moteurs de recherche (tusksearch, giphy, iseek, findfiles et d'autres) ainsi qu'une nouvelle catégorie « blogs ».
-- Les résultats d'images devinent désormais leur type MIME à partir du chemin du fichier.
-- Supprime le moteur AOL abandonné et met à jour les dépendances Python.
+- Corrige la configuration « about » manquante du moteur Anaconda.
+- Supprime les moteurs de médias ChinaSo arrêtés.
 
-Changements complets : https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
+Changements complets : https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,23 +3,23 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.15:0',
+  version: '2026.6.16:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.15. A small maintenance release: normalized engine configuration attributes and fixed language support for engines that declare their languages via traits.
+    en_US: `Updated SearXNG to 2026.6.16. A small maintenance release: a deprecation warning for the obsolete engine \`about.language\` property, and a fix for minimal container setup.
 
-Full changes: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
-    es_ES: `Actualiza SearXNG a 2026.6.15. Una pequeña versión de mantenimiento: se normalizaron los atributos de configuración de los motores y se corrigió el soporte de idiomas para los motores que declaran sus idiomas mediante traits.
+Full changes: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
+    es_ES: `Actualiza SearXNG a 2026.6.16. Una pequeña versión de mantenimiento: un aviso de obsolescencia para la propiedad obsoleta \`about.language\` de los motores y una corrección para la configuración mínima del contenedor.
 
-Cambios completos: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.15. Eine kleine Wartungsversion: Die Konfigurationsattribute der Suchmaschinen wurden normalisiert und die Sprachunterstützung für Suchmaschinen behoben, die ihre Sprachen über Traits angeben.
+Cambios completos: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.16. Eine kleine Wartungsversion: eine Veraltungswarnung für die obsolete Suchmaschinen-Eigenschaft \`about.language\` und eine Korrektur für die minimale Container-Einrichtung.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.15. Niewielkie wydanie konserwacyjne: znormalizowano atrybuty konfiguracji wyszukiwarek i naprawiono obsługę języków dla wyszukiwarek deklarujących swoje języki za pomocą traits.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.16. Niewielkie wydanie konserwacyjne: ostrzeżenie o wycofaniu nieaktualnej właściwości wyszukiwarki \`about.language\` oraz poprawka minimalnej konfiguracji kontenera.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.15. Une petite version de maintenance : normalisation des attributs de configuration des moteurs et correction de la prise en charge des langues pour les moteurs qui déclarent leurs langues via des traits.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.16. Une petite version de maintenance : un avertissement d'obsolescence pour la propriété obsolète \`about.language\` des moteurs et une correction pour la configuration minimale du conteneur.
 
-Changements complets : https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8`,
+Changements complets : https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,23 +3,23 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.16:0',
+  version: '2026.6.18:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.16. A small maintenance release: a deprecation warning for the obsolete engine \`about.language\` property, and a fix for minimal container setup.
+    en_US: `Updated SearXNG to 2026.6.18. Adds the Swiss search.ch/web engine and fixes the chinaso engine to handle empty upstream results gracefully.
 
-Full changes: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
-    es_ES: `Actualiza SearXNG a 2026.6.16. Una pequeña versión de mantenimiento: un aviso de obsolescencia para la propiedad obsoleta \`about.language\` de los motores y una corrección para la configuración mínima del contenedor.
+Full changes: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
+    es_ES: `Actualiza SearXNG a 2026.6.18. Añade el motor suizo search.ch/web y corrige el motor chinaso para gestionar correctamente los resultados vacíos del proveedor.
 
-Cambios completos: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.16. Eine kleine Wartungsversion: eine Veraltungswarnung für die obsolete Suchmaschinen-Eigenschaft \`about.language\` und eine Korrektur für die minimale Container-Einrichtung.
+Cambios completos: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.18. Fügt die Schweizer Suchmaschine search.ch/web hinzu und behebt die chinaso-Suchmaschine, sodass leere Ergebnisse der Quelle korrekt behandelt werden.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.16. Niewielkie wydanie konserwacyjne: ostrzeżenie o wycofaniu nieaktualnej właściwości wyszukiwarki \`about.language\` oraz poprawka minimalnej konfiguracji kontenera.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.18. Dodaje szwajcarską wyszukiwarkę search.ch/web i naprawia wyszukiwarkę chinaso, aby poprawnie obsługiwała puste wyniki z serwera źródłowego.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.16. Une petite version de maintenance : un avertissement d'obsolescence pour la propriété obsolète \`about.language\` des moteurs et une correction pour la configuration minimale du conteneur.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.18. Ajoute le moteur suisse search.ch/web et corrige le moteur chinaso pour gérer correctement les résultats vides du fournisseur.
 
-Changements complets : https://github.com/searxng/searxng/compare/cf1410af8...502c820a2`,
+Changements complets : https://github.com/searxng/searxng/compare/502c820a2...bd73cc09e`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,23 +3,43 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.20:0',
+  version: '2026.6.22:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.20. A maintenance release that fixes the ChatNoir engine to stop re-using and caching session keys.
+    en_US: `Updated SearXNG to 2026.6.22.
 
-Full changes: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
-    es_ES: `Actualiza SearXNG a 2026.6.20. Versión de mantenimiento que corrige el motor ChatNoir para que deje de reutilizar y almacenar en caché las claves de sesión.
+- Adds several new search engines (tusksearch, giphy, iseek, findfiles, and others) and a new "blogs" category.
+- Image results now guess their mimetype from the file path.
+- Removes the discontinued AOL engine and bumps Python dependencies.
 
-Cambios completos: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.20. Eine Wartungsversion, die die ChatNoir-Suchmaschine korrigiert, sodass sie Sitzungsschlüssel nicht mehr wiederverwendet und zwischenspeichert.
+Full changes: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
+    es_ES: `Actualiza SearXNG a 2026.6.22.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.20. Wydanie konserwacyjne, które naprawia wyszukiwarkę ChatNoir, aby przestała ponownie używać i buforować klucze sesji.
+- Añade varios motores de búsqueda nuevos (tusksearch, giphy, iseek, findfiles y otros) y una nueva categoría "blogs".
+- Los resultados de imágenes ahora deducen su tipo MIME a partir de la ruta del archivo.
+- Elimina el motor AOL descontinuado y actualiza las dependencias de Python.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.20. Une version de maintenance qui corrige le moteur ChatNoir afin qu'il cesse de réutiliser et de mettre en cache les clés de session.
+Cambios completos: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.22.
 
-Changements complets : https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
+- Fügt mehrere neue Suchmaschinen (tusksearch, giphy, iseek, findfiles und weitere) sowie eine neue Kategorie "Blogs" hinzu.
+- Bildergebnisse ermitteln ihren MIME-Typ jetzt anhand des Dateipfads.
+- Entfernt die eingestellte AOL-Suchmaschine und aktualisiert die Python-Abhängigkeiten.
+
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.22.
+
+- Dodaje kilka nowych wyszukiwarek (tusksearch, giphy, iseek, findfiles i inne) oraz nową kategorię „blogi".
+- Wyniki obrazów określają teraz typ MIME na podstawie ścieżki pliku.
+- Usuwa wycofaną wyszukiwarkę AOL i aktualizuje zależności Pythona.
+
+Pełna lista zmian: https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.22.
+
+- Ajoute plusieurs nouveaux moteurs de recherche (tusksearch, giphy, iseek, findfiles et d'autres) ainsi qu'une nouvelle catégorie « blogs ».
+- Les résultats d'images devinent désormais leur type MIME à partir du chemin du fichier.
+- Supprime le moteur AOL abandonné et met à jour les dépendances Python.
+
+Changements complets : https://github.com/searxng/searxng/compare/fd42d4fda...952896d29`,
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,23 +3,23 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.19:0',
+  version: '2026.6.20:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.19. A maintenance release: fixes a calculator crash on invalid expressions, assigns proper categories to several xpath engines (ayo, gabanza, zapmeta, abcnyheter), and refreshes translations.
+    en_US: `Updated SearXNG to 2026.6.20. A maintenance release that fixes the ChatNoir engine to stop re-using and caching session keys.
 
-Full changes: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
-    es_ES: `Actualiza SearXNG a 2026.6.19. Versión de mantenimiento: corrige un fallo de la calculadora con expresiones no válidas, asigna categorías correctas a varios motores xpath (ayo, gabanza, zapmeta, abcnyheter) y actualiza las traducciones.
+Full changes: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
+    es_ES: `Actualiza SearXNG a 2026.6.20. Versión de mantenimiento que corrige el motor ChatNoir para que deje de reutilizar y almacenar en caché las claves de sesión.
 
-Cambios completos: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.19. Eine Wartungsversion: behebt einen Absturz des Taschenrechners bei ungültigen Ausdrücken, weist mehreren xpath-Suchmaschinen (ayo, gabanza, zapmeta, abcnyheter) korrekte Kategorien zu und aktualisiert die Übersetzungen.
+Cambios completos: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.20. Eine Wartungsversion, die die ChatNoir-Suchmaschine korrigiert, sodass sie Sitzungsschlüssel nicht mehr wiederverwendet und zwischenspeichert.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.19. Wydanie konserwacyjne: naprawia awarię kalkulatora przy nieprawidłowych wyrażeniach, przypisuje właściwe kategorie kilku wyszukiwarkom xpath (ayo, gabanza, zapmeta, abcnyheter) i odświeża tłumaczenia.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.20. Wydanie konserwacyjne, które naprawia wyszukiwarkę ChatNoir, aby przestała ponownie używać i buforować klucze sesji.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.19. Une version de maintenance : corrige un plantage de la calculatrice sur les expressions invalides, attribue des catégories correctes à plusieurs moteurs xpath (ayo, gabanza, zapmeta, abcnyheter) et met à jour les traductions.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.20. Une version de maintenance qui corrige le moteur ChatNoir afin qu'il cesse de réutiliser et de mettre en cache les clés de session.
 
-Changements complets : https://github.com/searxng/searxng/compare/bd73cc09e...5c38d2fea`,
+Changements complets : https://github.com/searxng/searxng/compare/5c38d2fea...fd42d4fda`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the SearXNG Docker image from `2026.6.15` upstream maintenance release.

- **SearXNG**: `searxng/searxng:2026.6.14-b3e08f2a4` → `searxng/searxng:2026.6.15-cf1410af8`
- StartOS version: `2026.6.14:0` → `2026.6.15:0`

`@start9labs/start-sdk` is already at the latest published version (1.5.3); no SDK bump. Sidecars (`valkey:8-alpine`, `caddy:2-alpine`) track rolling major tags and were left untouched.

## What changed upstream

A small maintenance release — two commits in the bump range:

- `[chore]` complete and normalize the attributes of engine objects (#6258)
- `[fix]` set `language_support` for engines with languages in traits (#6258)

No user-visible behavior, interface, or config changes, so README/instructions need no edits.

Full changes: https://github.com/searxng/searxng/compare/b3e08f2a4...cf1410af8

## Test plan

- `npm run check` (tsc --noEmit) — green.