### PR TITLE
chore: bump SearXNG to 2026.6.26; 2026.6.24:0 → 2026.6.26:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
+      "integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.24-e3126b89e',
+        dockerTag: 'searxng/searxng:2026.6.26-f8ffbf36f',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,38 +3,23 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.24:0',
+  version: '2026.6.26:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.24. A small maintenance release.
+    en_US: `Updated SearXNG to 2026.6.26. A translations-only maintenance release with no functional changes.
 
-- Fixes the Anaconda engine's missing "about" configuration.
-- Removes the terminated ChinaSo media engines.
+Full changes: https://github.com/searxng/searxng/compare/e3126b89e...f8ffbf36f`,
+    es_ES: `Actualiza SearXNG a 2026.6.26. Una versión de mantenimiento solo de traducciones, sin cambios funcionales.
 
-Full changes: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    es_ES: `Actualiza SearXNG a 2026.6.24. Una pequeña versión de mantenimiento.
+Cambios completos: https://github.com/searxng/searxng/compare/e3126b89e...f8ffbf36f`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.26. Eine reine Übersetzungs-Wartungsversion ohne funktionale Änderungen.
 
-- Corrige la configuración "about" que faltaba en el motor Anaconda.
-- Elimina los motores de medios ChinaSo descontinuados.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/e3126b89e...f8ffbf36f`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.26. Wersja konserwacyjna zawierająca wyłącznie tłumaczenia, bez zmian funkcjonalnych.
 
-Cambios completos: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.24. Eine kleine Wartungsversion.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/e3126b89e...f8ffbf36f`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.26. Une version de maintenance ne contenant que des traductions, sans changement fonctionnel.
 
-- Behebt die fehlende "about"-Konfiguration der Anaconda-Suchmaschine.
-- Entfernt die eingestellten ChinaSo-Medien-Suchmaschinen.
-
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.24. Niewielka wersja konserwacyjna.
-
-- Naprawia brakującą konfigurację „about" w wyszukiwarce Anaconda.
-- Usuwa wycofane wyszukiwarki multimediów ChinaSo.
-
-Pełna lista zmian: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.24. Une petite version de maintenance.
-
-- Corrige la configuration « about » manquante du moteur Anaconda.
-- Supprime les moteurs de médias ChinaSo arrêtés.
-
-Changements complets : https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+Changements complets : https://github.com/searxng/searxng/compare/e3126b89e...f8ffbf36f`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Upstream bump

Bumps the SearXNG image from `2026.6.24-e3126b89e` to `2026.6.26-f8ffbf36f`.

This is a **translations-only** maintenance release — the sole upstream change in the range is a Weblate l10n update ([#6320](https://github.com/searxng/searxng/pull/6320)). No functional, behavioral, or config changes.

Full upstream diff: https://github.com/searxng/searxng/compare/e3126b89e...f8ffbf36f

## StartOS version

`2026.6.24:0` → `2026.6.26:0` (edited `current.ts` in place; existing config migration carried forward unchanged).

## Other

- `start-sdk` already at latest (1.5.3) — no bump.
- `npm update` floated the `prettier` dev-dep 3.8.4 → 3.8.5; no runtime deps changed.
- Valkey (`8-alpine`) and Caddy (`2-alpine`) sidecars unchanged.
- README / instructions need no changes (no user-visible behavior change).

## Test plan

- [x] `npm run check` (tsc) green.