### PR TITLE
chore: bump SearXNG to 2026.6.28; 2026.6.24:0 → 2026.6.28:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
+      "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.24-e3126b89e',
+        dockerTag: 'searxng/searxng:2026.6.28-357662d86',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,38 +3,23 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.24:0',
+  version: '2026.6.28:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.24. A small maintenance release.
+    en_US: `Updated SearXNG to 2026.6.28. A minor maintenance release containing only translation updates and CI dependency bumps; no user-facing functional changes.
 
-- Fixes the Anaconda engine's missing "about" configuration.
-- Removes the terminated ChinaSo media engines.
+Full changes: https://github.com/searxng/searxng/compare/e3126b89e...357662d86`,
+    es_ES: `Actualiza SearXNG a 2026.6.28. Una versión de mantenimiento menor que solo contiene actualizaciones de traducciones y mejoras de dependencias de CI; sin cambios funcionales para el usuario.
 
-Full changes: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    es_ES: `Actualiza SearXNG a 2026.6.24. Una pequeña versión de mantenimiento.
+Cambios completos: https://github.com/searxng/searxng/compare/e3126b89e...357662d86`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.28. Eine kleine Wartungsversion mit ausschließlich Übersetzungsaktualisierungen und CI-Abhängigkeits-Updates; keine für Benutzer sichtbaren Funktionsänderungen.
 
-- Corrige la configuración "about" que faltaba en el motor Anaconda.
-- Elimina los motores de medios ChinaSo descontinuados.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/e3126b89e...357662d86`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.28. Niewielka wersja konserwacyjna zawierająca jedynie aktualizacje tłumaczeń i zależności CI; brak zmian funkcjonalnych widocznych dla użytkownika.
 
-Cambios completos: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.24. Eine kleine Wartungsversion.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/e3126b89e...357662d86`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.28. Une version de maintenance mineure contenant uniquement des mises à jour de traductions et de dépendances CI ; aucun changement fonctionnel visible par l'utilisateur.
 
-- Behebt die fehlende "about"-Konfiguration der Anaconda-Suchmaschine.
-- Entfernt die eingestellten ChinaSo-Medien-Suchmaschinen.
-
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.24. Niewielka wersja konserwacyjna.
-
-- Naprawia brakującą konfigurację „about" w wyszukiwarce Anaconda.
-- Usuwa wycofane wyszukiwarki multimediów ChinaSo.
-
-Pełna lista zmian: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.24. Une petite version de maintenance.
-
-- Corrige la configuration « about » manquante du moteur Anaconda.
-- Supprime les moteurs de médias ChinaSo arrêtés.
-
-Changements complets : https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+Changements complets : https://github.com/searxng/searxng/compare/e3126b89e...357662d86`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the bundled SearXNG image from `2026.6.24-e3126b89e` to `2026.6.28-357662d86`, taking the StartOS version to **2026.6.28:0**.

This is a minor upstream maintenance release — the only commits in the range are translation updates from Weblate and CI/github-actions dependency bumps. No user-facing functional changes.

Full upstream diff: https://github.com/searxng/searxng/compare/e3126b89e...357662d86

## Changes

- `startos/manifest/index.ts` — `images.searxng.source.dockerTag` → `searxng/searxng:2026.6.28-357662d86`
- `startos/versions/current.ts` — `version` → `2026.6.28:0`, refreshed `releaseNotes` (all locales). Existing migration carried forward unchanged.
- `npm update` (no start-sdk bump — already at latest 1.5.3).

Valkey (`8-alpine`) and Caddy (`2-alpine`) sidecars unchanged — rolling major tags, no major bump due.

## Test plan

- `npm run check` (tsc) — green.