### PR TITLE
chore: bump SearXNG to 2026.6.29; 2026.6.24:0 → 2026.6.29:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.3.tgz",
+      "integrity": "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.24-e3126b89e',
+        dockerTag: 'searxng/searxng:2026.6.29-cb4bfbe12',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,38 +3,43 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.24:0',
+  version: '2026.6.29:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.24. A small maintenance release.
+    en_US: `Updated SearXNG to 2026.6.29. A maintenance release adding new search engines.
 
-- Fixes the Anaconda engine's missing "about" configuration.
-- Removes the terminated ChinaSo media engines.
+- Adds new image engines (picjumbo, StockSnap, Shopify stock images, magnific) and the neosearch general engine.
+- Adds related-search suggestions to the Tiger engine and fixes its captcha paths.
+- Fixes unclickable images in Resulthunter results.
 
-Full changes: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    es_ES: `Actualiza SearXNG a 2026.6.24. Una pequeña versión de mantenimiento.
+Full changes: https://github.com/searxng/searxng/compare/e3126b89e...cb4bfbe12`,
+    es_ES: `Actualiza SearXNG a 2026.6.29. Una versión de mantenimiento que añade nuevos motores de búsqueda.
 
-- Corrige la configuración "about" que faltaba en el motor Anaconda.
-- Elimina los motores de medios ChinaSo descontinuados.
+- Añade nuevos motores de imágenes (picjumbo, StockSnap, imágenes de stock de Shopify, magnific) y el motor general neosearch.
+- Añade sugerencias de búsquedas relacionadas al motor Tiger y corrige sus rutas de captcha.
+- Corrige las imágenes no clicables en los resultados de Resulthunter.
 
-Cambios completos: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.24. Eine kleine Wartungsversion.
+Cambios completos: https://github.com/searxng/searxng/compare/e3126b89e...cb4bfbe12`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.29. Eine Wartungsversion mit neuen Suchmaschinen.
 
-- Behebt die fehlende "about"-Konfiguration der Anaconda-Suchmaschine.
-- Entfernt die eingestellten ChinaSo-Medien-Suchmaschinen.
+- Fügt neue Bild-Suchmaschinen (picjumbo, StockSnap, Shopify-Stockbilder, magnific) und die allgemeine Suchmaschine neosearch hinzu.
+- Fügt der Tiger-Suchmaschine Vorschläge für verwandte Suchanfragen hinzu und behebt ihre Captcha-Pfade.
+- Behebt nicht anklickbare Bilder in Resulthunter-Ergebnissen.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.24. Niewielka wersja konserwacyjna.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/e3126b89e...cb4bfbe12`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.29. Wersja konserwacyjna dodająca nowe wyszukiwarki.
 
-- Naprawia brakującą konfigurację „about" w wyszukiwarce Anaconda.
-- Usuwa wycofane wyszukiwarki multimediów ChinaSo.
+- Dodaje nowe wyszukiwarki obrazów (picjumbo, StockSnap, obrazy stockowe Shopify, magnific) oraz ogólną wyszukiwarkę neosearch.
+- Dodaje sugestie powiązanych wyszukiwań do wyszukiwarki Tiger i naprawia jej ścieżki captcha.
+- Naprawia nieklikalne obrazy w wynikach Resulthunter.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.24. Une petite version de maintenance.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/e3126b89e...cb4bfbe12`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.29. Une version de maintenance ajoutant de nouveaux moteurs de recherche.
 
-- Corrige la configuration « about » manquante du moteur Anaconda.
-- Supprime les moteurs de médias ChinaSo arrêtés.
+- Ajoute de nouveaux moteurs d'images (picjumbo, StockSnap, images de stock Shopify, magnific) et le moteur général neosearch.
+- Ajoute des suggestions de recherches associées au moteur Tiger et corrige ses chemins de captcha.
+- Corrige les images non cliquables dans les résultats de Resulthunter.
 
-Changements complets : https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+Changements complets : https://github.com/searxng/searxng/compare/e3126b89e...cb4bfbe12`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the bundled SearXNG image from `2026.6.24-e3126b89e` to `2026.6.29-cb4bfbe12` (18 upstream commits). StartOS version: `2026.6.24:0` → `2026.6.29:0`.

A maintenance release that mostly adds new search engines:

- New image engines: picjumbo, StockSnap, Shopify stock images, magnific.
- New general engine: neosearch.org.
- Tiger engine gains related-search suggestions; captcha paths fixed.
- Fixes unclickable images in Resulthunter results.
- Routine Weblate translation and `searx.data` refreshes; CI action bumps.

Full upstream diff: https://github.com/searxng/searxng/compare/e3126b89e...cb4bfbe12

Valkey (`valkey/valkey:8-alpine`) and Caddy (`caddy:2-alpine`) sidecars are unchanged — they track rolling major tags.

`@start9labs/start-sdk` is already at the latest published version (1.5.3); no SDK bump. `npm update` floated a dev-only `prettier` 3.8.4 → 3.9.3.

## Test plan

- [x] `npm run check` (tsc) passes.