### PR TITLE
chore: bump SearXNG to 2026.6.30; 2026.6.24:0 → 2026.6.30:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.24-e3126b89e',
+        dockerTag: 'searxng/searxng:2026.6.30-774616ada',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,38 +3,43 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.24:0',
+  version: '2026.6.30:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.24. A small maintenance release.
+    en_US: `Updated SearXNG to 2026.6.30.
 
-- Fixes the Anaconda engine's missing "about" configuration.
-- Removes the terminated ChinaSo media engines.
+- Adds new image engines (picjumbo, StockSnap, Shopify stock images, magnific) and the neosearch general engine.
+- Adds related-search suggestions to the tiger engine and time-range support to bilibili.
+- Fixes results for baidu, naver, and qwant, and makes resulthunter result images clickable again.
 
-Full changes: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    es_ES: `Actualiza SearXNG a 2026.6.24. Una pequeña versión de mantenimiento.
+Full changes: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
+    es_ES: `Actualiza SearXNG a 2026.6.30.
 
-- Corrige la configuración "about" que faltaba en el motor Anaconda.
-- Elimina los motores de medios ChinaSo descontinuados.
+- Añade nuevos motores de imágenes (picjumbo, StockSnap, imágenes de stock de Shopify, magnific) y el motor general neosearch.
+- Añade sugerencias de búsqueda relacionada al motor tiger y soporte de rango de tiempo a bilibili.
+- Corrige resultados de baidu, naver y qwant, y hace que las imágenes de resultados de resulthunter vuelvan a ser clicables.
 
-Cambios completos: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.24. Eine kleine Wartungsversion.
+Cambios completos: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
+    de_DE: `Aktualisiert SearXNG auf 2026.6.30.
 
-- Behebt die fehlende "about"-Konfiguration der Anaconda-Suchmaschine.
-- Entfernt die eingestellten ChinaSo-Medien-Suchmaschinen.
+- Fügt neue Bild-Suchmaschinen hinzu (picjumbo, StockSnap, Shopify-Stockbilder, magnific) sowie die allgemeine Suchmaschine neosearch.
+- Fügt verwandte Suchvorschläge zur tiger-Suchmaschine und Zeitbereichsunterstützung zu bilibili hinzu.
+- Behebt Ergebnisse für baidu, naver und qwant und macht resulthunter-Ergebnisbilder wieder anklickbar.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.24. Niewielka wersja konserwacyjna.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
+    pl_PL: `Aktualizuje SearXNG do 2026.6.30.
 
-- Naprawia brakującą konfigurację „about" w wyszukiwarce Anaconda.
-- Usuwa wycofane wyszukiwarki multimediów ChinaSo.
+- Dodaje nowe wyszukiwarki obrazów (picjumbo, StockSnap, obrazy stockowe Shopify, magnific) oraz ogólną wyszukiwarkę neosearch.
+- Dodaje sugestie powiązanych wyszukiwań do wyszukiwarki tiger oraz obsługę zakresu czasu do bilibili.
+- Naprawia wyniki dla baidu, naver i qwant oraz przywraca klikalność obrazów wyników resulthunter.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.24. Une petite version de maintenance.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
+    fr_FR: `Met à jour SearXNG vers 2026.6.30.
 
-- Corrige la configuration « about » manquante du moteur Anaconda.
-- Supprime les moteurs de médias ChinaSo arrêtés.
+- Ajoute de nouveaux moteurs d'images (picjumbo, StockSnap, images de stock Shopify, magnific) et le moteur général neosearch.
+- Ajoute des suggestions de recherche associée au moteur tiger et la prise en charge de la plage horaire à bilibili.
+- Corrige les résultats de baidu, naver et qwant, et rend à nouveau cliquables les images de résultats de resulthunter.
 
-Changements complets : https://github.com/searxng/searxng/compare/952896d29...e3126b89e`,
+Changements complets : https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the wrapped SearXNG image from `2026.6.24-e3126b89e` to `2026.6.30-774616ada`. StartOS version `2026.6.24:0` → `2026.6.30:0`.

Valkey (`8-alpine`) and Caddy (`2-alpine`) sidecars stay on their rolling major tags. No `@start9labs/start-sdk` bump (already at latest 1.5.3); `npm update` floated one transitive dependency.

### Upstream highlights (2026.6.24 → 2026.6.30)

- New image engines: picjumbo, StockSnap, Shopify stock images, magnific; plus the neosearch general engine.
- Related-search suggestions added to the tiger engine; time-range support added to bilibili.
- Fixes for baidu, naver, and qwant result parsing; resulthunter result images are clickable again.

Full changes: https://github.com/searxng/searxng/compare/e3126b89e...774616ada

## Test plan

- [x] `npm run check` (typecheck) green.
- [ ] `make` / s9pk pack verified in review.