### PR TITLE
chore: bump SearXNG to 2026.7.1; 2026.6.30:0 → 2026.7.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.6.30-774616ada',
+        dockerTag: 'searxng/searxng:2026.7.1-c5d8d05f0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,43 +3,38 @@ import { readFile, rm } from 'fs/promises'
 import { settingsYaml } from '../fileModels/settings.yml'
 
 export const current = VersionInfo.of({
-  version: '2026.6.30:0',
+  version: '2026.7.1:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.6.30.
+    en_US: `Updated SearXNG to 2026.7.1.
 
-- Adds new image engines (picjumbo, StockSnap, Shopify stock images, magnific) and the neosearch general engine.
-- Adds related-search suggestions to the tiger engine and time-range support to bilibili.
-- Fixes results for baidu, naver, and qwant, and makes resulthunter result images clickable again.
+- Adds the new sina search engine.
+- Fixes searchzee results by working around bot-blocking, and cleans up engine setup/init internals.
 
-Full changes: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
-    es_ES: `Actualiza SearXNG a 2026.6.30.
+Full changes: https://github.com/searxng/searxng/compare/774616ada...c5d8d05f0`,
+    es_ES: `Actualiza SearXNG a 2026.7.1.
 
-- Añade nuevos motores de imágenes (picjumbo, StockSnap, imágenes de stock de Shopify, magnific) y el motor general neosearch.
-- Añade sugerencias de búsqueda relacionada al motor tiger y soporte de rango de tiempo a bilibili.
-- Corrige resultados de baidu, naver y qwant, y hace que las imágenes de resultados de resulthunter vuelvan a ser clicables.
+- Añade el nuevo motor de búsqueda sina.
+- Corrige los resultados de searchzee evitando el bloqueo de bots y limpia la lógica interna de configuración e inicialización de motores.
 
-Cambios completos: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
-    de_DE: `Aktualisiert SearXNG auf 2026.6.30.
+Cambios completos: https://github.com/searxng/searxng/compare/774616ada...c5d8d05f0`,
+    de_DE: `Aktualisiert SearXNG auf 2026.7.1.
 
-- Fügt neue Bild-Suchmaschinen hinzu (picjumbo, StockSnap, Shopify-Stockbilder, magnific) sowie die allgemeine Suchmaschine neosearch.
-- Fügt verwandte Suchvorschläge zur tiger-Suchmaschine und Zeitbereichsunterstützung zu bilibili hinzu.
-- Behebt Ergebnisse für baidu, naver und qwant und macht resulthunter-Ergebnisbilder wieder anklickbar.
+- Fügt die neue Suchmaschine sina hinzu.
+- Behebt searchzee-Ergebnisse durch Umgehung der Bot-Blockierung und bereinigt die interne Einrichtung und Initialisierung von Suchmaschinen.
 
-Vollständige Änderungen: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
-    pl_PL: `Aktualizuje SearXNG do 2026.6.30.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/774616ada...c5d8d05f0`,
+    pl_PL: `Aktualizuje SearXNG do 2026.7.1.
 
-- Dodaje nowe wyszukiwarki obrazów (picjumbo, StockSnap, obrazy stockowe Shopify, magnific) oraz ogólną wyszukiwarkę neosearch.
-- Dodaje sugestie powiązanych wyszukiwań do wyszukiwarki tiger oraz obsługę zakresu czasu do bilibili.
-- Naprawia wyniki dla baidu, naver i qwant oraz przywraca klikalność obrazów wyników resulthunter.
+- Dodaje nową wyszukiwarkę sina.
+- Naprawia wyniki searchzee, omijając blokowanie botów, oraz porządkuje wewnętrzną konfigurację i inicjalizację wyszukiwarek.
 
-Pełna lista zmian: https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
-    fr_FR: `Met à jour SearXNG vers 2026.6.30.
+Pełna lista zmian: https://github.com/searxng/searxng/compare/774616ada...c5d8d05f0`,
+    fr_FR: `Met à jour SearXNG vers 2026.7.1.
 
-- Ajoute de nouveaux moteurs d'images (picjumbo, StockSnap, images de stock Shopify, magnific) et le moteur général neosearch.
-- Ajoute des suggestions de recherche associée au moteur tiger et la prise en charge de la plage horaire à bilibili.
-- Corrige les résultats de baidu, naver et qwant, et rend à nouveau cliquables les images de résultats de resulthunter.
+- Ajoute le nouveau moteur de recherche sina.
+- Corrige les résultats de searchzee en contournant le blocage des bots et nettoie la configuration et l'initialisation internes des moteurs.
 
-Changements complets : https://github.com/searxng/searxng/compare/e3126b89e...774616ada`,
+Changements complets : https://github.com/searxng/searxng/compare/774616ada...c5d8d05f0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the bundled SearXNG image `2026.6.30-774616ada` → `2026.7.1-c5d8d05f0` and sets the StartOS version to `2026.7.1:0`.

Upstream changes in this range:
- Adds the new **sina** search engine.
- Fixes **searchzee** results by working around bot-blocking.
- Cleans up engine `setup`/`init` internals.

Full upstream diff: https://github.com/searxng/searxng/compare/774616ada...c5d8d05f0

start-sdk is already at the latest npm release (1.5.3) — no SDK bump. `npm update` produced no lockfile changes. Valkey and Caddy remain on their rolling major tags (`8-alpine` / `2-alpine`).

## Test plan

- [x] `npm run check` (typecheck) passes.