### PR TITLE
chore: bump SearXNG to 2026.7.24; 2026.7.19:1 → 2026.7.24:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1735,7 +1735,7 @@
       }
     },
     "node_modules/tor-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#e3e2b53a84cb92855ac7b35764df288fab1fa333",
+      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#aa867cfea0f20095feb56e96cad3510393d912de",
       "dependencies": {
         "@noble/curves": "*",
         "@start9labs/start-sdk": "2.0.7",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.7.19-6da6eee26',
+        dockerTag: 'searxng/searxng:2026.7.24-4f64d9501',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,33 +1,48 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2026.7.19:1',
+  version: '2026.7.24:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.7.19.
+    en_US: `Updated SearXNG to 2026.7.24.
 
-SearXNG ships rolling releases without individual changelogs; this bump picks up engine and dependency updates published since 2026.7.13.
+A minor maintenance release. SearXNG ships rolling releases without individual changelogs; only two commits landed upstream since 2026.7.19:
 
-This release also migrates the package to start-sdk 2.0 (requires StartOS 0.4.0-beta.10 or later).`,
-    es_ES: `Actualiza SearXNG a 2026.7.19.
+- The container now ignores invalid SEARXNG_PORT values instead of failing to start.
+- Internal continuous-integration dependency refresh.
 
-SearXNG publica versiones continuas sin registros de cambios individuales; esta actualización incorpora las mejoras de motores y dependencias publicadas desde la 2026.7.13.
+Full upstream changes: https://github.com/searxng/searxng/compare/6da6eee26...4f64d9501`,
+    es_ES: `Actualiza SearXNG a 2026.7.24.
 
-Esta versión también migra el paquete a start-sdk 2.0 (requiere StartOS 0.4.0-beta.10 o posterior).`,
-    de_DE: `Aktualisiert SearXNG auf 2026.7.19.
+Una versión de mantenimiento menor. SearXNG publica versiones continuas sin registros de cambios individuales; solo se incorporaron dos commits desde la 2026.7.19:
 
-SearXNG veröffentlicht fortlaufende Versionen ohne einzelne Änderungsprotokolle; diese Aktualisierung übernimmt die seit 2026.7.13 veröffentlichten Engine- und Abhängigkeitsaktualisierungen.
+- El contenedor ahora ignora los valores no válidos de SEARXNG_PORT en lugar de no iniciarse.
+- Actualización interna de una dependencia de integración continua.
 
-Diese Version stellt das Paket außerdem auf start-sdk 2.0 um (erfordert StartOS 0.4.0-beta.10 oder neuer).`,
-    pl_PL: `Aktualizuje SearXNG do 2026.7.19.
+Cambios completos: https://github.com/searxng/searxng/compare/6da6eee26...4f64d9501`,
+    de_DE: `Aktualisiert SearXNG auf 2026.7.24.
 
-SearXNG publikuje wydania ciągłe bez osobnych list zmian; ta aktualizacja obejmuje zmiany silników i zależności opublikowane od wersji 2026.7.13.
+Eine kleine Wartungsversion. SearXNG veröffentlicht fortlaufende Versionen ohne einzelne Änderungsprotokolle; seit 2026.7.19 sind nur zwei Commits hinzugekommen:
 
-Ta wersja przenosi też pakiet na start-sdk 2.0 (wymaga StartOS 0.4.0-beta.10 lub nowszego).`,
-    fr_FR: `Met à jour SearXNG vers 2026.7.19.
+- Der Container ignoriert nun ungültige SEARXNG_PORT-Werte, anstatt nicht zu starten.
+- Interne Aktualisierung einer Continuous-Integration-Abhängigkeit.
 
-SearXNG publie des versions en continu sans journal des modifications individuel ; cette mise à jour intègre les évolutions des moteurs et des dépendances publiées depuis la 2026.7.13.
+Vollständige Änderungen: https://github.com/searxng/searxng/compare/6da6eee26...4f64d9501`,
+    pl_PL: `Aktualizuje SearXNG do 2026.7.24.
 
-Cette version fait également passer le paquet à start-sdk 2.0 (nécessite StartOS 0.4.0-beta.10 ou une version ultérieure).`,
+Drobna aktualizacja konserwacyjna. SearXNG publikuje wydania ciągłe bez osobnych list zmian; od wersji 2026.7.19 pojawiły się tylko dwa commity:
+
+- Kontener ignoruje teraz nieprawidłowe wartości SEARXNG_PORT zamiast nie uruchamiać się.
+- Wewnętrzna aktualizacja zależności integracji ciągłej.
+
+Pełne zmiany: https://github.com/searxng/searxng/compare/6da6eee26...4f64d9501`,
+    fr_FR: `Met à jour SearXNG vers 2026.7.24.
+
+Une version de maintenance mineure. SearXNG publie des versions en continu sans journal des modifications individuel ; seuls deux commits ont été ajoutés depuis la 2026.7.19 :
+
+- Le conteneur ignore désormais les valeurs SEARXNG_PORT non valides au lieu de ne pas démarrer.
+- Actualisation interne d'une dépendance d'intégration continue.
+
+Changements complets : https://github.com/searxng/searxng/compare/6da6eee26...4f64d9501`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Routine monitor-cycle bump of the SearXNG upstream image.

- **SearXNG** `2026.7.19-6da6eee26` → `2026.7.24-4f64d9501` (`images.searxng.source.dockerTag`). Verified on Docker Hub: the tag resolves with both `amd64` and `arm64` images (published 2026-07-24).
- **StartOS version** `2026.7.19:1` → `2026.7.24:0` (new upstream resets the revision to `:0`; `2026.7.24:0` is not yet on the registry, which currently has `2026.7.19:1` as latest).
- **tor-startos#next** git pin refreshed `e3e2b53` → `aa867cf`. Its delta in this window is only an internal `start-sdk` 2.0.7 bump — no changes to the `utils` (`socksHostId`/`socksPort`) that this package imports.
- **start-sdk** already at the latest npm release (`2.0.7`); no SDK bump.

## Upstream changes

Only two commits landed upstream between the pinned builds — this is a minor maintenance release:

- `[fix] container: ignore invalid SEARXNG_PORT values (#6439)` — the container entrypoint now tolerates an invalid `SEARXNG_PORT` instead of failing to start. Does not affect this package (the port is set explicitly).
- `[upd] github-actions: Bump docker/login-action from 4.4.0 to 4.5.0 (#6442)` — internal CI only.

Full upstream compare: https://github.com/searxng/searxng/compare/6da6eee26...4f64d9501

The `valkey:8-alpine` and `caddy:2-alpine` sidecar pins are rolling major tags and were left untouched (no major bump).

## Verification

- `npm run check` (tsc `--noEmit`) — green.
- `package-lock.json` reconverged (git deps re-resolved from scratch, byte-stable across repeat installs; no stale nested `@start9labs/start-sdk`).
- Release notes updated for all five locales; translations independently verified.
- README / instructions reviewed — no version- or behavior-specific references touched by this bump.

Per the monitor cycle, `make` / s9pk pack is deferred to review.