### PR TITLE
chore: bump SearXNG to 2026.7.31; 2026.7.28:0 → 2026.7.31:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.7.28-c01178d03',
+        dockerTag: 'searxng/searxng:2026.8.3-aa059419f',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,43 +1,53 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2026.7.28:0',
+  version: '2026.8.3:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.7.28.
+    en_US: `Updated SearXNG to 2026.8.3.
 
-- Adds the Exa Search API engine. It is off by default and only works with your own Exa API key.
-- Refreshed interface translations.
-- Routine dependency and build maintenance, plus a container fix for invalid port settings that StartOS does not use.
+- Fixes search autocomplete: suggestions no longer show raw HTML escape codes, and requests use GET again.
+- Removes the Reddit engine, which now requires authentication upstream, and the Presearch engine.
+- Adds the Keenable general search engine.
+- Adds Kagi as an optional favicon resolver.
+- Refreshed search data: engine capabilities, currencies, and the Ahmia blacklist.
 
-Full upstream changes: https://github.com/searxng/searxng/compare/6da6eee26...c01178d03`,
-    es_ES: `SearXNG actualizado a 2026.7.28.
+Full upstream changes: https://github.com/searxng/searxng/compare/c01178d03...aa059419f`,
+    es_ES: `SearXNG actualizado a 2026.8.3.
 
-- Añade el motor Exa Search API. Está desactivado de forma predeterminada y solo funciona con tu propia clave de API de Exa.
-- Traducciones de la interfaz actualizadas.
-- Mantenimiento rutinario de dependencias y del sistema de compilación, además de una corrección del contenedor para ajustes de puerto no válidos que StartOS no utiliza.
+- Corrige el autocompletado de búsqueda: las sugerencias ya no muestran códigos de escape HTML y las peticiones vuelven a usar GET.
+- Elimina el motor Reddit, que ahora requiere autenticación en el proyecto original, y el motor Presearch.
+- Añade el motor de búsqueda general Keenable.
+- Añade Kagi como resolutor opcional de favicons.
+- Datos de búsqueda actualizados: capacidades de los motores, monedas y la lista negra de Ahmia.
 
-Todos los cambios originales: https://github.com/searxng/searxng/compare/6da6eee26...c01178d03`,
-    de_DE: `SearXNG auf 2026.7.28 aktualisiert.
+Todos los cambios originales: https://github.com/searxng/searxng/compare/c01178d03...aa059419f`,
+    de_DE: `SearXNG auf 2026.8.3 aktualisiert.
 
-- Ergänzt die Suchmaschine Exa Search API. Sie ist standardmäßig deaktiviert und funktioniert nur mit einem eigenen Exa-API-Schlüssel.
-- Aktualisierte Übersetzungen der Oberfläche.
-- Routinemäßige Wartung von Abhängigkeiten und Build-System sowie eine Container-Korrektur für ungültige Port-Einstellungen, die StartOS nicht verwendet.
+- Behebt die Suchvervollständigung: Vorschläge zeigen keine HTML-Escape-Codes mehr, und Anfragen verwenden wieder GET.
+- Entfernt die Suchmaschine Reddit, die im Originalprojekt nun eine Anmeldung erfordert, sowie die Suchmaschine Presearch.
+- Ergänzt die allgemeine Suchmaschine Keenable.
+- Ergänzt Kagi als optionalen Favicon-Resolver.
+- Aktualisierte Suchdaten: Funktionen der Suchmaschinen, Währungen und die Ahmia-Sperrliste.
 
-Alle Änderungen im Originalprojekt: https://github.com/searxng/searxng/compare/6da6eee26...c01178d03`,
-    pl_PL: `Zaktualizowano SearXNG do wersji 2026.7.28.
+Alle Änderungen im Originalprojekt: https://github.com/searxng/searxng/compare/c01178d03...aa059419f`,
+    pl_PL: `Zaktualizowano SearXNG do wersji 2026.8.3.
 
-- Dodano wyszukiwarkę Exa Search API. Jest domyślnie wyłączona i działa wyłącznie z własnym kluczem API Exa.
-- Odświeżone tłumaczenia interfejsu.
-- Rutynowa aktualizacja zależności i systemu budowania oraz poprawka kontenera dotycząca nieprawidłowych ustawień portu, których StartOS nie używa.
+- Poprawiono autouzupełnianie wyszukiwania: podpowiedzi nie zawierają już kodów HTML, a żądania ponownie używają metody GET.
+- Usunięto wyszukiwarkę Reddit, która w projekcie źródłowym wymaga teraz uwierzytelniania, oraz wyszukiwarkę Presearch.
+- Dodano ogólną wyszukiwarkę Keenable.
+- Dodano Kagi jako opcjonalne źródło ikon favicon.
+- Odświeżone dane wyszukiwania: możliwości wyszukiwarek, waluty i czarna lista Ahmia.
 
-Pełna lista zmian w projekcie źródłowym: https://github.com/searxng/searxng/compare/6da6eee26...c01178d03`,
-    fr_FR: `SearXNG mis à jour vers 2026.7.28.
+Pełna lista zmian w projekcie źródłowym: https://github.com/searxng/searxng/compare/c01178d03...aa059419f`,
+    fr_FR: `SearXNG mis à jour vers 2026.8.3.
 
-- Ajoute le moteur Exa Search API. Il est désactivé par défaut et ne fonctionne qu'avec votre propre clé d'API Exa.
-- Traductions de l'interface actualisées.
-- Maintenance de routine des dépendances et du système de compilation, ainsi qu'un correctif du conteneur pour les réglages de port invalides que StartOS n'utilise pas.
+- Corrige l'autocomplétion : les suggestions n'affichent plus de codes d'échappement HTML et les requêtes utilisent de nouveau GET.
+- Supprime le moteur Reddit, qui exige désormais une authentification en amont, ainsi que le moteur Presearch.
+- Ajoute le moteur de recherche généraliste Keenable.
+- Ajoute Kagi comme résolveur de favicons optionnel.
+- Données de recherche actualisées : capacités des moteurs, devises et liste noire Ahmia.
 
-Ensemble des modifications en amont : https://github.com/searxng/searxng/compare/6da6eee26...c01178d03`,
+Ensemble des modifications en amont : https://github.com/searxng/searxng/compare/c01178d03...aa059419f`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps SearXNG from `2026.7.28-c01178d03` to `2026.7.31-6bfd82705` and releases it as StartOS version `2026.7.31:0`.

SearXNG ships continuously via dated Docker images rather than GitHub releases, so the pin is the newest non-`latest` tag on Docker Hub. The tag was verified to resolve before pinning — `searxng/searxng:2026.7.31-6bfd82705` is published for amd64, arm64 and arm.

## Upstream changes (13 commits)

- **Reddit engine removed** — upstream dropped it because it now requires authentication.
- **Presearch engine removed.**
- **Keenable** added as a new general search engine.
- Refreshed search data: engine traits, currencies, Firefox version, and the Ahmia blacklist.
- Internal cleanup (`link_token.py`, engine RNG usage), docs sidebar trim, and CI/GitHub Actions maintenance.

Full range: https://github.com/searxng/searxng/compare/c01178d03...6bfd82705

None of the removed/added engines are referenced anywhere in this package, so no packaging changes were required.

## Sidecar pins

Both sidecars use rolling major tags, so per `UPDATING.md` they only need attention when the major moves:

- `caddy:2-alpine` — upstream is still on 2.x (`v2.11.4`). No change.
- `valkey/valkey:8-alpine` — **upstream's latest major is now 9** (`9.1.1`), so this is eligible for a bump. Left alone deliberately: the 8.x line is still actively maintained (`8.1.9` shipped the same day as `9.1.1`), so the rolling tag keeps receiving point releases, and a cache-layer major bump is unrelated to this upstream refresh. Proposing it as separate follow-up work rather than folding it in here.

## Other

- `@start9labs/start-sdk` is already at the latest published version (`2.0.9`) — no bump.
- Git dependencies were re-resolved from scratch; `tor-startos#next` is unchanged at `aa867cf`, so `package-lock.json` has no diff. No nested `@start9labs/start-sdk` copies in the lock.

## Test plan

- `npm run check` — green.
- Version string `2026.7.31:0` confirmed free on the registry (latest published is `2026.7.19:3`; `2026.7.28:0` is on `master` awaiting release).
