### PR TITLE
docs: stop advertising the deprecated .startos DNS name for the JSON endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ StartOS manages a `store.json` file and a `settings.yml` file in the `main` volu
 
 ### Programmatic Search (JSON API)
 
-The instance is pre-configured to serve JSON-format search results, which makes it usable as a search backend for clients like Open WebUI's web-search feature. From any other StartOS package on the same server, the search endpoint is reachable at:
+The instance is pre-configured to serve JSON-format search results, which makes it usable as a search backend for clients like Open WebUI's web-search feature. The HTML UI is unaffected.
 
-```
-http://searxng.startos:80/search?q=<query>&format=json
-```
+A package consuming this endpoint resolves the address rather than hardcoding it — `sdk.host.getBridgeAddress` against this package's `mainHostId` and `uiPort` (both exported from `startos/interfaces.ts` and `startos/utils.ts`), giving `http://<bridge address>/search?q=<query>&format=json`. See [Service-to-Service Networking](https://docs.start9.com/packaging/service-to-service.html); [`open-webui-startos`](https://github.com/Start9Labs/open-webui-startos)'s `startos/main.ts` is a working example.
 
-The HTML UI is unaffected.
+> Earlier revisions of this document gave the endpoint as `http://searxng.startos:80/…`. That overlay DNS is deprecated and slated for removal, and it resolves to the container IP rather than the bridge — don't build against it.
+
+Note that the JSON endpoint is **not** behind the login the **Manage Access** action sets up: that gate is enforced by the StartOS reverse proxy on the TLS interface, while packages on the same server dial the plain-HTTP binding over the bridge. Turning on a password does not cut off a service you've connected.
 
 ## Network Access and Interfaces
 

--- a/instructions.md
+++ b/instructions.md
@@ -8,7 +8,7 @@
 
 - A **Web UI** interface — your private metasearch frontend aggregating results from 70+ search engines.
 - A **Stats Dashboard** interface, exported only when you turn stats on, showing usage and engine performance at `/stats`.
-- A `?format=json` search endpoint on the same Web UI, suitable as a backend for tools like Open WebUI's web-search feature. From another StartOS service on the same server, queries reach `http://searxng.startos:80/search?q=<query>&format=json`.
+- A `?format=json` search endpoint on the same Web UI, suitable as a backend for tools like Open WebUI's web-search feature. Other services on the same server connect to it privately, without going over the LAN or the internet — [Open WebUI](https://github.com/Start9Labs/open-webui-startos) fills the address in for you, so there is nothing to copy by hand.
 - Caddy in front of SearXNG handling security headers, and Valkey behind it for caching — you don't manage either.
 - Your instance is **public by default** — anyone with the address can use it. You can optionally require a login (username `admin` plus a password) with the **Manage Access** action; it covers both the Web UI and the Stats Dashboard.
 


### PR DESCRIPTION
`README.md` and `instructions.md` both told consumers to reach the JSON search endpoint at `http://searxng.startos:80/search?q=<query>&format=json`. That overlay DNS is deprecated and slated for removal, and it resolves to the container IP rather than the bridge, so it bypasses the platform — the packaging guide lists it as a forbidden pattern (`projects/start-sdk/docs/src/service-to-service.md`).

`README.md` now points packagers at `sdk.host.getBridgeAddress` against this package's exported `mainHostId` / `uiPort`, links Service-to-Service Networking and [`open-webui-startos`](https://github.com/Start9Labs/open-webui-startos) as a worked example, and keeps a short note recording what the old URL was and why not to build against it.

`instructions.md` is end-user documentation, so it drops the address entirely: consuming services connect privately and Open WebUI fills the address in itself — there was never anything for a user to copy.

Also documents something a consumer needs and neither file stated: the JSON endpoint is **not** behind the login the Manage Access action sets up. That gate is attached to `AddSslOptions.auth` and the OS only hangs it on vhosts keyed to the SSL port (`shared-libs/crates/start-core/src/net/net_controller.rs`), while packages dial the plain-HTTP binding over the bridge. Setting a password does not cut off a service you've connected.

**No version bump:** both files are `*.md` and `tagAndRelease.yml` has `paths-ignore: ['*.md']`. Note this leaves the corrected `instructions.md` unreleased until the next code change, since it ships inside the `.s9pk`; a `2026.7.28:1` bump would get it out now if preferred.

Companion to [Start9Labs/open-webui-startos#31](https://github.com/Start9Labs/open-webui-startos/pull/31), which fixes the underlying wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
