### PR TITLE
chore: bump SearXNG to 2026.8.12; 2026.8.4:0 → 2026.8.12:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -26,7 +26,7 @@ export const manifest = setupManifest({
     },
     searxng: {
       source: {
-        dockerTag: 'searxng/searxng:2026.8.4-c63835bd2',
+        dockerTag: 'searxng/searxng:2026.8.12-cdfdaa5a8',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,48 +1,53 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2026.8.4:0',
+  version: '2026.8.12:0',
   releaseNotes: {
-    en_US: `Updated SearXNG to 2026.8.4.
+    en_US: `Updated SearXNG to 2026.8.12.
 
-A small maintenance release:
+- Searches now use GET instead of POST by default, so the browser back button works and result pages can be bookmarked and shared.
+- Autocomplete suggestions are now on by default, powered by DuckDuckGo.
+- Adds Jina as a general search engine.
+- Dogpile no longer fails with access-denied errors, but is now inactive by default.
+- Updated Persian, Irish and Hebrew translations.
 
-- Adds Kagi as an option for search autocomplete suggestions, selectable under Preferences.
-- Refreshed the unit data used to convert measurements in answers.
+Full upstream changes: https://github.com/searxng/searxng/compare/c63835bd2...cdfdaa5a8`,
+    es_ES: `SearXNG actualizado a 2026.8.12.
 
-Full upstream changes: https://github.com/searxng/searxng/compare/aa059419f...c63835bd2`,
-    es_ES: `SearXNG actualizado a 2026.8.4.
+- Las búsquedas usan ahora GET en lugar de POST de forma predeterminada, por lo que el botón de retroceso del navegador funciona y las páginas de resultados se pueden guardar en marcadores y compartir.
+- Las sugerencias de autocompletado están activadas de forma predeterminada, mediante DuckDuckGo.
+- Añade Jina como motor de búsqueda general.
+- Dogpile ya no falla con errores de acceso denegado, pero queda inactivo de forma predeterminada.
+- Traducciones actualizadas al persa, irlandés y hebreo.
 
-Una pequeña versión de mantenimiento:
+Todos los cambios originales: https://github.com/searxng/searxng/compare/c63835bd2...cdfdaa5a8`,
+    de_DE: `SearXNG auf 2026.8.12 aktualisiert.
 
-- Añade Kagi como opción para las sugerencias de autocompletado, seleccionable en Preferencias.
-- Datos de unidades actualizados para convertir medidas en las respuestas.
+- Suchanfragen verwenden jetzt standardmäßig GET statt POST, sodass die Zurück-Schaltfläche des Browsers funktioniert und Ergebnisseiten als Lesezeichen gespeichert und geteilt werden können.
+- Vorschläge zur Autovervollständigung sind jetzt standardmäßig aktiv und nutzen DuckDuckGo.
+- Ergänzt Jina als allgemeine Suchmaschine.
+- Dogpile scheitert nicht mehr an Zugriffsfehlern, ist aber jetzt standardmäßig inaktiv.
+- Aktualisierte Übersetzungen für Persisch, Irisch und Hebräisch.
 
-Todos los cambios originales: https://github.com/searxng/searxng/compare/aa059419f...c63835bd2`,
-    de_DE: `SearXNG auf 2026.8.4 aktualisiert.
+Alle Änderungen im Originalprojekt: https://github.com/searxng/searxng/compare/c63835bd2...cdfdaa5a8`,
+    pl_PL: `Zaktualizowano SearXNG do wersji 2026.8.12.
 
-Eine kleine Wartungsversion:
+- Wyszukiwania domyślnie korzystają teraz z metody GET zamiast POST, dzięki czemu działa przycisk wstecz w przeglądarce, a strony wyników można dodawać do zakładek i udostępniać.
+- Podpowiedzi autouzupełniania są domyślnie włączone i korzystają z DuckDuckGo.
+- Dodano Jina jako ogólną wyszukiwarkę.
+- Dogpile nie kończy się już błędami odmowy dostępu, ale jest domyślnie nieaktywny.
+- Zaktualizowano tłumaczenia na perski, irlandzki i hebrajski.
 
-- Ergänzt Kagi als Option für die Suchvervollständigung, auswählbar unter Einstellungen.
-- Aktualisierte Einheitendaten für die Umrechnung von Maßangaben in Antworten.
+Pełna lista zmian w projekcie źródłowym: https://github.com/searxng/searxng/compare/c63835bd2...cdfdaa5a8`,
+    fr_FR: `SearXNG mis à jour vers 2026.8.12.
 
-Alle Änderungen im Originalprojekt: https://github.com/searxng/searxng/compare/aa059419f...c63835bd2`,
-    pl_PL: `Zaktualizowano SearXNG do wersji 2026.8.4.
+- Les recherches utilisent désormais GET plutôt que POST par défaut : le bouton retour du navigateur fonctionne et les pages de résultats peuvent être mises en favori et partagées.
+- Les suggestions d'autocomplétion sont activées par défaut, via DuckDuckGo.
+- Ajoute Jina comme moteur de recherche généraliste.
+- Dogpile n'échoue plus avec des erreurs d'accès refusé, mais est désormais inactif par défaut.
+- Traductions persane, irlandaise et hébraïque mises à jour.
 
-Niewielkie wydanie konserwacyjne:
-
-- Dodano Kagi jako źródło podpowiedzi autouzupełniania, do wyboru w Preferencjach.
-- Odświeżono dane jednostek używane do przeliczania miar w odpowiedziach.
-
-Pełna lista zmian w projekcie źródłowym: https://github.com/searxng/searxng/compare/aa059419f...c63835bd2`,
-    fr_FR: `SearXNG mis à jour vers 2026.8.4.
-
-Une petite version de maintenance :
-
-- Ajoute Kagi comme source de suggestions d'autocomplétion, sélectionnable dans les Préférences.
-- Données d'unités actualisées pour la conversion des mesures dans les réponses.
-
-Ensemble des modifications en amont : https://github.com/searxng/searxng/compare/aa059419f...c63835bd2`,
+Ensemble des modifications en amont : https://github.com/searxng/searxng/compare/c63835bd2...cdfdaa5a8`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps SearXNG from `2026.8.4-c63835bd2` to `2026.8.12-cdfdaa5a8` (the newest tag on Docker Hub, same digest as `latest`). StartOS version `2026.8.4:0` → `2026.8.12:0`.

Nothing else moved: `@start9labs/start-sdk` is already on 2.0.9 (npm latest), and the `tor-startos#next` git dep re-resolved to the same commit (`aa867cf`), so `package-lock.json` is unchanged.

## Upstream changes ([c63835bd2...cdfdaa5a8](https://github.com/searxng/searxng/compare/c63835bd2...cdfdaa5a8))

- **Searches default to `GET` instead of `POST`.** The browser back button now works and result pages can be bookmarked and shared. This package sets `use_default_settings: true` and does not override `server.method`, so the new default applies.
- **Autocomplete now defaults to DuckDuckGo** (previously off). Same story — `search.autocomplete` isn't overridden by the package.
- Adds Jina as a general search engine.
- Dogpile's "access denied" failure (missing origin header) is fixed, but the engine is now inactive by default.
- Search errors no longer dump full tracebacks outside debug mode.
- Updated Persian, Irish and Hebrew translations.

## Verification

- `searxng/searxng:2026.8.12-cdfdaa5a8` confirmed on Docker Hub with `amd64` + `arm64` manifests (digest `sha256:c2dc2d9e…`, identical to `latest`).
- `2026.8.12:0` is not published on the registry.
- `npm run check` green. Per the monitor cycle, no `make` / s9pk pack — that's for review.

## Proposal (not implemented)

Valkey has cut a **9.x** major (latest release 9.1.1) and `valkey/valkey:9-alpine` exists. Per `UPDATING.md` the sidecar pin only moves on a major change, so `valkey/valkey:8-alpine` is now a major behind. I've deliberately left it alone rather than ride an untested major cache bump on an upstream refresh — it wants its own PR with a runtime check that the limiter/cache still comes up over the `/var/run/valkey.sock` unix socket. Same for `caddy:2-alpine`, which is still current (2.11.4).
